### PR TITLE
Add the Azure Boards badge to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,4 @@
+[![Board Status](https://dev.azure.com/DemoMario/ea2a4b15-f5a2-470d-b17a-7cbd5da87b49/e7bbbdac-153a-4f5b-aecf-a83f036158f9/_apis/work/boardbadge/a4ff2453-31b7-4b84-8e76-88874dfac544)](https://dev.azure.com/DemoMario/ea2a4b15-f5a2-470d-b17a-7cbd5da87b49/_boards/board/t/e7bbbdac-153a-4f5b-aecf-a83f036158f9/Microsoft.RequirementCategory)
 ![CoverImage](https://github.com/user-attachments/assets/db930cee-8f0f-47b3-9729-9da8c3b6b2c1)
 
 # Overview


### PR DESCRIPTION
Add the Azure Boards badge for the board used to track the work for this repository. Fixes [AB#1](https://dev.azure.com/DemoMario/ea2a4b15-f5a2-470d-b17a-7cbd5da87b49/_workitems/edit/1). See the [status badge configuration](https://aka.ms/azureboardsgithub-badge) documentation for more information.